### PR TITLE
Fix byte string encoding error, rework environment variable access

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
   - "3.5-dev"
   - "3.6"
   - "3.6-dev"
-  - "nightly"
 sudo: required
 dist: trusty
 addons:

--- a/pynoc/apc.py
+++ b/pynoc/apc.py
@@ -257,7 +257,7 @@ class APC(object):
 
     @property
     def serial_number(self):
-        """Serial number.
+        """Return the serial number.
 
         :return: PDU serial number
         """
@@ -267,7 +267,7 @@ class APC(object):
 
     @property
     def num_outlets(self):
-        """Number of outlets in the PDU.
+        """Return the number of outlets in the PDU.
 
         :return: total number of outlets in the PDU
         """
@@ -277,7 +277,7 @@ class APC(object):
 
     @property
     def num_switched_outlets(self):
-        """Number of switched outlets in the PDU.
+        """Return the number of switched outlets in the PDU.
 
         :return: number of switched outlets in the PDU
         """
@@ -287,7 +287,7 @@ class APC(object):
 
     @property
     def num_metered_outlets(self):
-        """Number of metered outlets in the PDU.
+        """Return the number of metered outlets in the PDU.
 
         :return: number of metered outlets in the PDU
         """
@@ -331,7 +331,7 @@ class APC(object):
 
     @property
     def current(self):
-        """The current utilization of the PDU.
+        """Return the current utilization of the PDU.
 
         :return: current, in amps
         """
@@ -345,7 +345,7 @@ class APC(object):
 
     @property
     def power(self):
-        """The power utilization of the PDU.
+        """Return the power utilization of the PDU.
 
         :return: power, in kW
         """

--- a/pynoc/cisco.py
+++ b/pynoc/cisco.py
@@ -269,7 +269,7 @@ class CiscoSwitch(object):
 
     @property
     def version(self):
-        """The Cisco IOS version.
+        """Retrieve the Cisco IOS version.
 
         :return: The Cisco IOS version.
         """
@@ -283,7 +283,7 @@ class CiscoSwitch(object):
 
     @property
     def host(self):
-        """The IP address or hostname of the switch.
+        """Retrieve the IP address or hostname of the switch.
 
         :return: IP address or hostname of the switch
         """

--- a/pynoc/cisco.py
+++ b/pynoc/cisco.py
@@ -41,6 +41,8 @@ class CiscoSwitch(object):
     CMD_VLAN_SET = 'switchport access vlan {0}'
     CMD_VLAN_SHOW = 'sh vlan'
 
+    CMD_CARRIAGE_RETURN = ''
+
     CMD_END = 'end'
 
     PORT_NOTATION = {
@@ -83,7 +85,9 @@ class CiscoSwitch(object):
                              look_for_keys=False)
         self._shell = self._client.invoke_shell()
         self._ready = True
-        output = self._send_command('', self.CMD_LOGIN_SIGNALS)
+        output = self._send_command(
+            self.CMD_CARRIAGE_RETURN, self.CMD_LOGIN_SIGNALS
+        )
         if output.find('>') > 0:
             self._enable_needed = True
             self._ready = False
@@ -288,7 +292,9 @@ class CiscoSwitch(object):
 
         :return: has a connection to the switch been made?
         """
-        output = self._send_command('', self.CMD_GENERIC_SIGNALS)
+        output = self._send_command(
+            self.CMD_CARRIAGE_RETURN, self.CMD_GENERIC_SIGNALS
+        )
         active_ssh = any(self.CMD_GENERIC_SIGNALS in output)
         return self._shell is not None and active_ssh
 

--- a/pynoc/cisco.py
+++ b/pynoc/cisco.py
@@ -295,7 +295,7 @@ class CiscoSwitch(object):
         output = self._send_command(
             self.CMD_CARRIAGE_RETURN, self.CMD_GENERIC_SIGNALS
         )
-        active_ssh = any(self.CMD_GENERIC_SIGNALS in output)
+        active_ssh = any(self.CMD_LOGIN_SIGNALS in output)
         return self._shell is not None and active_ssh
 
     def _shorthand_port_notation(self, port):

--- a/pynoc/cisco.py
+++ b/pynoc/cisco.py
@@ -343,7 +343,7 @@ class CiscoSwitch(object):
         """
         send_command = command + '\n'
         if log:
-            self._logger.info('Sending command: %s', send_command)
+            self._logger.info('Sending command: %s', send_command.strip())
 
         self._shell.send(send_command)
 

--- a/pynoc/cisco.py
+++ b/pynoc/cisco.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from six import PY3
 from netaddr import EUI, mac_unix_expanded
 from paramiko import SSHClient, AutoAddPolicy
 
@@ -338,7 +339,10 @@ class CiscoSwitch(object):
 
         read_buffer = ''
         while not any(read_buffer.find(signal) > -1 for signal in signals):
-            read_buffer += self._shell.recv(self.MAX_COMMAND_READ)
+            read = self._shell.recv(self.MAX_COMMAND_READ)
+            if PY3:  # If running in python3, convert byte string to native str
+                read = read.decode()
+            read_buffer += read
 
         if log:
             self._logger.debug('Received output: %s', read_buffer)

--- a/pynoc/cisco.py
+++ b/pynoc/cisco.py
@@ -293,9 +293,11 @@ class CiscoSwitch(object):
         :return: has a connection to the switch been made?
         """
         output = self._send_command(
-            self.CMD_CARRIAGE_RETURN, self.CMD_GENERIC_SIGNALS
+            self.CMD_CARRIAGE_RETURN, self.CMD_LOGIN_SIGNALS
         )
-        active_ssh = any(self.CMD_LOGIN_SIGNALS in output)
+        active_ssh = any(
+            signal in output for signal in self.CMD_LOGIN_SIGNALS
+        )
         return self._shell is not None and active_ssh
 
     def _shorthand_port_notation(self, port):

--- a/pynoc/cisco.py
+++ b/pynoc/cisco.py
@@ -288,7 +288,9 @@ class CiscoSwitch(object):
 
         :return: has a connection to the switch been made?
         """
-        return self._shell is not None
+        output = self._send_command('', self.CMD_GENERIC_SIGNALS)
+        active_ssh = any(self.CMD_GENERIC_SIGNALS in output)
+        return self._shell is not None and active_ssh
 
     def _shorthand_port_notation(self, port):
         """Shorthand port notation.

--- a/pynoc/cisco.py
+++ b/pynoc/cisco.py
@@ -10,6 +10,9 @@ from paramiko import SSHClient, AutoAddPolicy
 class CiscoSwitch(object):
     """Cisco switch control."""
 
+    # pylint: disable=len-as-condition
+    # Parsing command line output has uncertain lengths
+
     MAX_COMMAND_READ = 16
 
     CMD_LOGIN_SIGNALS = ['>', '#']
@@ -315,7 +318,7 @@ class CiscoSwitch(object):
         lower = port.lower()
         output = port
 
-        if any(lower.find(port) == 0 for port in self.PORT_NOTATION.keys()):
+        if any(lower.find(port) == 0 for port in self.PORT_NOTATION):
             for item in self.PORT_NOTATION.items():
                 if lower.startswith(item[0]):
                     output = lower.replace(item[0], item[1])

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ snmpy
 netaddr
 paramiko
 retrying
+six

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: System :: Hardware',
         'Topic :: System :: Networking',
     ],
@@ -45,6 +46,7 @@ setup(
     packages=find_packages(exclude=['contrib', 'docs', 'test*']),
 
     install_requires=[
+        'six',
         'pysnmp',
         'snmpy',
         'paramiko',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pynoc',
-    version='1.4.2',
+    version='1.4.3',
 
     description='Network Operation Center gear',
     long_description='Python package to handle interact with various '

--- a/tests/TestAPC.py
+++ b/tests/TestAPC.py
@@ -11,14 +11,14 @@ TEST_ENV_PRIVATE_COMMUNITY = "APC_PRIVATE_COMMUNITY"
 class TestAPC(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        apc_address = os.getenv(TEST_ENV_IP_ADDRESS)
+        apc_address = os.environ['TEST_ENV_IP_ADDRESS']
         if apc_address is None:
             raise EnvironmentError(ENV_NOT_SET.format(TEST_ENV_IP_ADDRESS))
-        public_community = os.getenv(TEST_ENV_PUBLIC_COMMUNITY)
+        public_community = os.environ['TEST_ENV_PUBLIC_COMMUNITY']
         if public_community is None:
             raise EnvironmentError(
                 ENV_NOT_SET.format(TEST_ENV_PUBLIC_COMMUNITY))
-        private_community = os.getenv(TEST_ENV_PRIVATE_COMMUNITY)
+        private_community = os.environ['TEST_ENV_PRIVATE_COMMUNITY']
         if private_community is None:
             raise EnvironmentError(
                 ENV_NOT_SET.format(TEST_ENV_PRIVATE_COMMUNITY))

--- a/tests/TestCiscoSwitch.py
+++ b/tests/TestCiscoSwitch.py
@@ -12,16 +12,16 @@ TEST_ENV_ENABLE_PASSWORD = "CISCO_ENABLE_PASSWORD"
 class TestCisco(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cisco_address = os.getenv(TEST_ENV_IP_ADDRESS)
+        cisco_address = os.environ['TEST_ENV_IP_ADDRESS']
         if cisco_address is None:
             raise EnvironmentError(ENV_NOT_SET.format(TEST_ENV_IP_ADDRESS))
-        cisco_username = os.getenv(TEST_ENV_USERNAME)
+        cisco_username = os.environ['TEST_ENV_USERNAME']
         if cisco_username is None:
             raise EnvironmentError(ENV_NOT_SET.format(TEST_ENV_USERNAME))
-        cisco_password = os.getenv(TEST_ENV_PASSWORD)
+        cisco_password = os.environ['TEST_ENV_PASSWORD']
         if cisco_password is None:
             raise EnvironmentError(ENV_NOT_SET.format(TEST_ENV_PASSWORD))
-        cisco_enable_password = os.getenv(TEST_ENV_ENABLE_PASSWORD)
+        cisco_enable_password = os.environ['TEST_ENV_ENABLE_PASSWORD']
         if cisco_address is None:
             raise EnvironmentError(
                 ENV_NOT_SET.format(TEST_ENV_ENABLE_PASSWORD))


### PR DESCRIPTION
The strings returned by the `ssh` connection with a Cisco switch are, by default, encoded as byte strings. This is true in both Python 2 and Python 3. However, because the default string encoding for Python 3 has switched to Unicode, the byte string read buffer must be decoded.

The explicit Python 3 version check on line 343 is necessary, as calling `str.decode()` in python 2 will always return a unicode string so the runtime check prevents any breaking changes.

The `environ` mapping is merely for cross-platform OS compatibility in running tests.