### PR TITLE
Feature: add poe_limit to CiscoSwitch

### DIFF
--- a/pynoc/apc.py
+++ b/pynoc/apc.py
@@ -496,9 +496,8 @@ class APC(object):
             return name
         else:
             raise IndexError(
-                'Only %d outlets exist. "%s" is an invalid outlet.',
-                self._num_outlets, str(outlet)
-            )
+                'Only {} outlets exist. "{}" is an invalid outlet.'.format(
+                    self._num_outlets, str(outlet)))
 
     def set_outlet_name(self, outlet, name):
         """Update the name of an outlet in the PDU.
@@ -514,9 +513,8 @@ class APC(object):
             )
         else:
             raise IndexError(
-                'Only %d outlets exist. "%s" is an invalid outlet.',
-                self._num_outlets, str(outlet)
-            )
+                'Only {} outlets exist. "{}" is an invalid outlet.'.format(
+                    self._num_outlets, str(outlet)))
 
     def outlet_status(self, outlet):
         """Determine the status of the outlet in the PDU.
@@ -533,9 +531,8 @@ class APC(object):
             return self.OUTLET_STATUS_TYPES[state]
         else:
             raise IndexError(
-                'Only %d outlets exist. "%s" is an invalid outlet.',
-                self._num_outlets, str(outlet)
-            )
+                'Only {} outlets exist. "{}" is an invalid outlet.'.format(
+                    self._num_outlets, str(outlet)))
 
     def outlet_command(self, outlet, operation):
         """Send command to an outlet in the PDU.
@@ -547,9 +544,8 @@ class APC(object):
         valid_operations = ['on', 'off', 'reboot']
         if operation not in valid_operations:
             raise ValueError(
-                '"%s" is an invalid operation. Valid operations are: %s',
-                str(operation), str(valid_operations)
-            )
+                '"{}" is an invalid operation. Valid operations are: {}'.format(
+                    str(operation), str(valid_operations)))
 
         operations = {
             'on': 1,
@@ -578,9 +574,8 @@ class APC(object):
             return success
         else:
             raise IndexError(
-                'Only %d outlets exist. "%s" is an invalid outlet.',
-                self._num_outlets, str(outlet)
-            )
+                'Only {} outlets exist. "{}" is an invalid outlet.'.format(
+                    self._num_outlets, str(outlet)))
 
     @property
     def sensor_supports_temperature(self):

--- a/pynoc/cisco.py
+++ b/pynoc/cisco.py
@@ -46,6 +46,7 @@ class CiscoSwitch(object):
 
     CMD_POWER_OFF = 'power inline never'
     CMD_POWER_ON = 'power inline auto'
+    CMD_POWER_LIMIT = 'power inline auto max {0}'
     CMD_POWER_SHOW = 'sh power inline'
 
     CMD_CONFIGURE_INTERFACE = 'int {0}'
@@ -175,6 +176,26 @@ class CiscoSwitch(object):
 
         verify = self._send_command(self.CMD_POWER_SHOW)
         matches, _ = CiscoSwitch._verify_poe_status(verify, port, "off")
+        return matches
+
+    def poe_limit(self, port, milliwatts_limit):
+        """Enable a port for POE, but limit the maximum wattage.
+
+        :param port: port to enable POE on, e.g. Gi1/0/1
+        :param milliwatts_limit: the maximum wattage,
+            given in milliwatts, e.g. 15400. Cisco documentation
+            gives 4000 to 30000 as the valid range.
+        """
+        if not self.connected:
+            return False
+
+        port = self._shorthand_port_notation(port)
+        cmds = [self.CMD_CONFIGURE_INTERFACE.format(port),
+                self.CMD_POWER_LIMIT.format(milliwatts_limit)]
+        self._send_config(cmds)
+
+        verify = self._send_command(self.CMD_POWER_SHOW)
+        matches, _ = CiscoSwitch._verify_poe_status(verify, port, "on")
         return matches
 
     def is_poe(self, port):

--- a/pynoc/cisco.py
+++ b/pynoc/cisco.py
@@ -199,7 +199,7 @@ class CiscoSwitch(object):
         :return: True if the command succeeded, False otherwise
         """
         if not self.connected:
-            return
+            return False
 
         port = self._shorthand_port_notation(port)
         cmds = [
@@ -279,7 +279,7 @@ class CiscoSwitch(object):
         :return: shorthand port name
         """
         if port is None:
-            return
+            return ""
 
         lower = port.lower()
         output = port
@@ -389,7 +389,7 @@ class CiscoSwitch(object):
             # If the ignore_port is specified and is the port in question,
             # ignore it.
             ignore_port = self._shorthand_port_notation(ignore_port)
-            if ignore_port and values[3] == ignore_port:
+            if ignore_port == "" or values[3] == ignore_port:
                 continue
 
             lookup.append(

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,3 +17,4 @@ pdb-failures = 1
 
 [flake8]
 ignore = D203
+max-line-length = 80

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pynoc',
-    version='1.5.1',
+    version='1.6.0',
 
     description='Network Operation Center gear',
     long_description='Python package to handle interact with various '


### PR DESCRIPTION
Add a method to CiscoSwitch that allows for setting a maximum wattage for PoE while turning a given port on.